### PR TITLE
Fix segmentation fault when trying to count an inaccessible directory

### DIFF
--- a/source/file.cpp
+++ b/source/file.cpp
@@ -290,6 +290,11 @@ std::vector<Entry> Sonne::WalkDirectory(std::string path)
     Entry first = GetFSEntry(path, false);
 #endif
 
+    if (!first.isValid)
+    {
+        return entries;
+    }
+
     while (true)
     {
         Entry next = GetNextEntry(root.fullPath, ((entries.size() == 0) ? first : entries.back()));


### PR DESCRIPTION
These commits include a quick fix for a segfault I was getting when running the program over a directory without the proper permissions to access it. Additionally, the Catch2 dependency is updated to 2.13.5 to fix the following error compiling on Linux:
```
In file included from /usr/include/signal.h:328,
                 from /home/jordan/dev/sonne/extern/Catch2/single_include/catch2/catch.hpp:8030,
                 from /home/jordan/dev/sonne/tests/main.cpp:2:
/home/jordan/dev/sonne/extern/Catch2/single_include/catch2/catch.hpp:10818:58: error: call to non-‘constexpr’ function ‘long int sysconf(int)’
10818 |     static constexpr std::size_t sigStackSize = 32768 >= MINSIGSTKSZ ? 32768 : MINSIGSTKSZ;
      |                                                          ^~~~~~~~~~~
In file included from /usr/include/x86_64-linux-gnu/bits/sigstksz.h:24,
                 from /usr/include/signal.h:328,
                 from /home/jordan/dev/sonne/extern/Catch2/single_include/catch2/catch.hpp:8030,
                 from /home/jordan/dev/sonne/tests/main.cpp:2:
/usr/include/unistd.h:640:17: note: ‘long int sysconf(int)’ declared here
  640 | extern long int sysconf (int __name) __THROW;
      |                 ^~~~~~~
In file included from /home/jordan/dev/sonne/tests/main.cpp:2:
/home/jordan/dev/sonne/extern/Catch2/single_include/catch2/catch.hpp:10877:45: error: size of array ‘altStackMem’ is not an integral constant-expression
10877 |     char FatalConditionHandler::altStackMem[sigStackSize] = {};
      |                                             ^~~~~~~~~~~~

```